### PR TITLE
fix: add process env for local variable

### DIFF
--- a/app/data/socialIconsData.tsx
+++ b/app/data/socialIconsData.tsx
@@ -137,7 +137,7 @@ const socialIconsData = [
   {
     id: 5,
     name: "Email",
-    url: "mailto: ${NEXT_PUBLIC_EMAIL_ADDRESS}",
+    url: "mailto: ${process.env.NEXT_PUBLIC_EMAIL_ADDRESS}",
     svg: (
       <svg
         width="24px"

--- a/app/data/socialIconsData.tsx
+++ b/app/data/socialIconsData.tsx
@@ -137,7 +137,7 @@ const socialIconsData = [
   {
     id: 5,
     name: "Email",
-    url: "mailto: ${process.env.NEXT_PUBLIC_EMAIL_ADDRESS}",
+    url: `mailto: ${process.env.NEXT_PUBLIC_EMAIL_ADDRESS}`,
     svg: (
       <svg
         width="24px"


### PR DESCRIPTION
### TL;DR

The pull request changes how we refer to the environment variable for the Email url in socialIconsData.

### What changed?

The URL for the Email object in socialIconsData.tsx has been updated to use `process.env` when referring to the `NEXT_PUBLIC_EMAIL_ADDRESS` environment variable.

### How to test?

To test, ensure that the NEXT_PUBLIC_EMAIL_ADDRESS environment variable is set, then see if clicking the email button in the social icons navigates to an email draft with the correct address.

### Why make this change?

The previous way to refer to the environment variable wasn't working correctly. This change is necessary to ensure we can use the ``NEXT_PUBLIC_EMAIL_ADDRESS`` environment variable to display an email link.

---

