### PR TITLE
feat(dynamic-post-util): create utils to dynamically gather all posts or individual post

### DIFF
--- a/app/lib/mdxUtils.ts
+++ b/app/lib/mdxUtils.ts
@@ -1,0 +1,42 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+import { serialize } from "next-mdx-remote/serialize";
+
+// Define the directory where MDX posts are stored
+const postsDirectory = path.join(process.cwd(), "posts");
+
+//* Function to get all posts with their metadata and content
+export const getPosts = () => {
+  // Read all file names in the posts directory
+  const files = fs.readdirSync(postsDirectory);
+  return files.map((file) => {
+    // Construct the full path of each file
+    const fullPath = path.join(postsDirectory, file);
+    // Read the contents of the file
+    const fileContents = fs.readFileSync(fullPath, "utf8");
+    // Use gray-matter to parse the post metadata section
+    const { data, content } = matter(fileContents);
+    return {
+      data, // Contains the post metadata
+      content, // Contains the post content
+      slug: file.replace(/\.mdx$/, ""), // Extract the slug from the file name
+    };
+  });
+};
+
+//* Function to get a single post by slug
+export const getSinglePost = async (slug: string) => {
+  // Construct the full path to the file using the slug
+  const fullPath = path.join(postsDirectory, `${slug}.mdx`);
+  // Read the contents of the file
+  const fileContents = fs.readFileSync(fullPath, "utf-8");
+  // Parse the file contents to separate metadata and content
+  const { data, content } = matter(fileContents);
+  // Serialize the MDX content to be rendered on the client side
+  const mdxSource = await serialize(content);
+  return {
+    mdxSource, // Serialized MDX content
+    ...data, // Spread the metadata
+  };
+};


### PR DESCRIPTION
### TL;DR

This PR introduces new utility functions (`getPosts` and `getSinglePost`) in `mdxUtils.ts` for processing MDX posts. These functions help in fetching all posts with their metadata and content, and fetching a single post by its slug.

### What changed?

New file `mdxUtils.ts` has been created with two new functions `getPosts` and `getSinglePost`. These utilities function help in fetching MDX posts and their metadata from the defined `postsDirectory`. `getSinglePost` also serializes the MDX content for client-side rendering.

### How to test?

To test these new functions, Content can be added into `posts` directory (in MDX format). These functions can be invoked to fetch and process the MDX content.

### Why make this change?

This change allows for efficient and organized processing and rendering of MDX content.

---

