### PR TITLE
refactor(HomeLanding): move landing page code to separate component for reusability

### DIFF
--- a/app/components/HomeLanding.tsx
+++ b/app/components/HomeLanding.tsx
@@ -1,0 +1,16 @@
+import SocialIconsList from "./SocialIconsList";
+
+export default function HomeLanding() {
+  return (
+    <section className="flex flex-auto flex-col items-center justify-center">
+      <h2 className="text-5xl">Christine Wessa</h2>
+      <SocialIconsList filter={["Instagram", "Facebook", "YouTube", "Email"]} />
+      <p className="max-w-80 text-balance pt-2  text-center text-sm">
+        To inquire about booking, send me a message at{" "}
+        <a href="mailto:bookchristinewessa@gmail.com" className="font-bold">
+          bookchristinewessa@gmail.com
+        </a>
+      </p>
+    </section>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,4 @@
-import SocialIconsList from "./components/SocialIconsList";
+import HomeLanding from "./components/HomeLanding";
 export default function Page() {
-  return (
-    <section className="flex flex-auto flex-col items-center justify-center">
-      <h2 className="text-5xl">Christine Wessa</h2>
-      <SocialIconsList filter={["Instagram", "Facebook", "YouTube", "Email"]} />
-      <p className="max-w-80 text-balance pt-2  text-center text-sm">
-        To inquire about booking, send me a message at{" "}
-        <a href="mailto:bookchristinewessa@gmail.com" className="font-bold">
-          bookchristinewessa@gmail.com
-        </a>
-      </p>
-    </section>
-  );
+  return <HomeLanding />;
 }


### PR DESCRIPTION
### TL;DR

This PR extracts the homepage landing section into a separate component for reusability and separation of concerns.

### What changed?

The home landing section of the `Page` component, including the title, social icons, and booking message, is moved to a new `HomeLanding` component. The `Page` component has been updated to use this new component.

### How to test?

After pulling the changes, ensure that the website's home landing section looks the same and that the component has been properly imported and used in the `Page` component.

### Why make this change?

As the codebase grows, it's important to maintain clean and maintainable code. By extracting the home landing section into its own component, we improve the reusability and readability of the code.

---

