### PR TITLE
feat(ui): add testimonials with basic styling

### DIFF
--- a/app/components/Home/HomeTestimonial.tsx
+++ b/app/components/Home/HomeTestimonial.tsx
@@ -1,0 +1,13 @@
+import { TestimonialList } from "../TestimonialList";
+export function HomeTestimonial() {
+  return (
+    <section className="border-b-1 border-slate-200 py-12">
+      <div className="mx-auto flex max-w-3xl flex-col gap-4">
+        <h2 className="text-balance text-center text-2xl">
+          Kinds Words from Kind People
+        </h2>
+        <TestimonialList />
+      </div>
+    </section>
+  );
+}

--- a/app/components/TestimonialCard.tsx
+++ b/app/components/TestimonialCard.tsx
@@ -1,0 +1,35 @@
+interface TestimonialCardProps {
+  name: string;
+  avatar: string;
+  role: string;
+  diocese?: string;
+  testimonial: string;
+}
+
+import Image from "next/image";
+
+export function TestimonialCard({
+  name,
+  avatar,
+  role,
+  diocese,
+  testimonial,
+}: TestimonialCardProps) {
+  return (
+    <div className="flex flex-col items-start">
+      <div className="overflow-clip rounded-md">
+        <img
+          src={avatar}
+          alt={`Avatar image of ${name + role}`}
+          width={150}
+          height={150}
+        />
+      </div>
+
+      <h3 className="text-xl">{name}</h3>
+      <p className="text-sm">{role}</p>
+      <p className="text-xs">{diocese}</p>
+      <p className="mt-4 text-pretty">{`"${testimonial}"`}</p>
+    </div>
+  );
+}

--- a/app/components/TestimonialList.tsx
+++ b/app/components/TestimonialList.tsx
@@ -1,0 +1,29 @@
+import { TestimonialCard } from "./TestimonialCard";
+import { testimonialsData } from "../data/testimonialsData";
+
+type testimonialsDataProps = {
+  id: number;
+  name: string;
+  avatar: string;
+  diocese: string;
+  role: string;
+  testimonial: string;
+};
+
+export function TestimonialList() {
+  const testimonials = testimonialsData;
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      {testimonials.map((testimonial: testimonialsDataProps) => (
+        <TestimonialCard
+          key={testimonial.id}
+          name={testimonial.name}
+          avatar={testimonial.avatar}
+          role={testimonial.role}
+          diocese={testimonial.diocese}
+          testimonial={testimonial.testimonial}
+        />
+      ))}
+    </div>
+  );
+}

--- a/app/data/testimonialsData.tsx
+++ b/app/data/testimonialsData.tsx
@@ -1,8 +1,8 @@
 export const testimonialsData = [
   {
     id: 1,
-    person: "Fr. Mary Mary, CFR",
-    avatar: "",
+    name: "Fr. Mary-Mary Ames, CFR",
+    avatar: "https://i.pravatar.cc/150?img=5",
     role: "CFR Brooklyn",
     diocese: "",
     testimonial:
@@ -10,8 +10,8 @@ export const testimonialsData = [
   },
   {
     id: 2,
-    person: "Very Rev. Fr. John Phillip Knight, V.F.",
-    avatar: "",
+    name: "Very Rev. Fr. John Phillip Knight, V.F.",
+    avatar: "https://i.pravatar.cc/150?img=50",
     role: "Pastor of St. John Vianney",
     diocese: "Archdiocese of Atlanta",
     testimonial:
@@ -19,9 +19,9 @@ export const testimonialsData = [
   },
   {
     id: 3,
-    person: "Chez Filipini",
-    avatar: "",
-    role: "Director of the Office of Marriage and Family Life",
+    name: "Chez Filipini",
+    avatar: "https://i.pravatar.cc/150?img=20",
+    role: "Director of Marriage and Family Life",
     diocese: "Diocese of Pensacola-Tallahassee",
     testimonial:
       "Christine is a uniquely gifted worship leader whose demeanor and musical excellence work together to foster beautiful moments of prayerfully encountering the Lord Jesus. She is capable of encouraging this spirit with different age groups who might have varying levels of experience or comfort in retreat settings. She is a joy to work with and displays a servant's heart in every planning conversation and email exchange.",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import { HomeHero } from "./components/Home/HomeHero";
 import { HomeInstagram } from "./components/Home/HomeInstagram";
 import { HomeMission } from "./components/Home/HomeMission";
 import { HomeStory } from "./components/Home/HomeStory";
+import { HomeTestimonial } from "./components/Home/HomeTestimonial";
 
 export default function Page() {
   return (


### PR DESCRIPTION
### TL;DR

This pull request introduces the 'HomeTestimonial' feature which adds a testimonial section to the homepage. 

### What changed?
- The 'TestimonialCard' and 'TestimonialList' components are created to display testimonials pulled from the 'testimonialsData' file. 
- The 'testimonialsData' file is also updated with avatar URLs and some text changes.

The contact form's input type was updated from 'text' to 'textarea'.

The testimonialsData file was updated to include the diocese field and a completed testimonial.

### How to test?

This change can be tested by verifying the aforementioned components and data file, and ensuring the testimonial section displays correctly on the homepage.

### Why make this change?

This change was necessary to bring social proof to the website. 

