### PR TITLE
feat(navigation): add hyperlinks to about and contact sections

### DIFF
--- a/app/components/Home/HomeContact.tsx
+++ b/app/components/Home/HomeContact.tsx
@@ -2,7 +2,7 @@ import { ContactForm } from "../ContactForm";
 
 export function HomeContact() {
   return (
-    <section className="border-b-1 border-slate-200 py-24">
+    <section className="border-b-1 border-slate-200 py-24" id="contact">
       <div className="mx-auto flex max-w-2xl flex-col gap-8 px-4">
         <div className="flex flex-col items-center gap-2 text-center">
           <h2 className="text-balance text-4xl">
@@ -13,7 +13,6 @@ export function HomeContact() {
             <span className="text-red-500">*</span>
           </p>
         </div>
-
         <ContactForm />
       </div>
     </section>

--- a/app/components/Home/HomeStory.tsx
+++ b/app/components/Home/HomeStory.tsx
@@ -4,7 +4,7 @@ import { SocialIconsList } from "../SocialIconsList";
 
 export function HomeStory() {
   return (
-    <section className="border-b-1 py-12">
+    <section className="border-b-1 py-12" id="about">
       <div className="grid grid-cols-2">
         <div className="p-2">
           <div className="relative min-h-[55dvh] overflow-hidden rounded-md">

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -2,13 +2,23 @@ import Link from "next/link";
 
 export function Navbar() {
   return (
-    <header className="flex px-2 py-3">
-      <div>
+    <header className="px-4 py-3">
+      <div className="flex w-full flex-row justify-between">
         <Link href="/">
-          <span className="font-display text-1xl font-normal">
+          <span className="font-display text-1xl font-bold">
             Christine Wessa
           </span>
         </Link>
+        <div className="flex flex-row gap-3">
+          <Link href="/#about">
+            <span className="font-display text-1xl font-normal">
+              Meet Christine
+            </span>
+          </Link>
+          <Link href="/#contact">
+            <span className="font-display text-1xl font-normal">Contact</span>
+          </Link>
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
### TL;DR

This PR adds in-page navigation links to the Navbar

### What changed?

Added navigation links to 'About' and 'Contact' sections in the Navbar. Also added `id` attributes to the 'About' and 'Contact' sections in `HomeStory.tsx` and `HomeContact.tsx` respectively, so they can be targeted by the new links.

### How to test?

Open the homepage and click on the 'Meet Christine' and 'Contact' links in the Navbar. The page should scroll to the respective sections.

### Why make this change?

These changes improve navigation on the site and enhance user experience.

---

