### PR TITLE
feat(navigation): update Facebook link to her new page

### DIFF
--- a/app/data/socialIconsData.tsx
+++ b/app/data/socialIconsData.tsx
@@ -38,7 +38,7 @@ export const socialIconsData = [
   {
     id: 2,
     name: "Facebook",
-    url: "https://www.facebook.com/christinesimpson.wessa.7",
+    url: "https://www.facebook.com/christinewessa",
     svg: (
       <svg
         width="24px"


### PR DESCRIPTION
### TL;DR

Updated the Facebook url from 'https://www.facebook.com/christinesimpson.wessa.7' to 'https://www.facebook.com/christinewessa' for social icon.

### What changed?

The url for the Facebook social icon in the `socialIconsData.tsx` file has been updated. The existing url was outdated and has been replaced with the new url.

### How to test?

Verify that the Facebook social icon now redirects to the updated url.

### Why make this change?

The update ensures that users are redirected to the correct Facebook profile when they click on the Facebook social icon.

---

