### PR TITLE
chore(deps): remove Million JS

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,13 +1,7 @@
-import MillionLint from "@million/lint";
 import { withContentCollections } from "@content-collections/next";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {};
 
-// Apply MillionLint first
-const withMillionLint = MillionLint.next({
-  rsc: true,
-});
-
-// Export the configuration with Content Collections as the last plugin
-export default withContentCollections(withMillionLint(nextConfig));
+// Export the configuration with Content Collections
+export default withContentCollections(nextConfig);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "clean": "rm -rf .next/ && rm -rf node_modules/ && npm install"
   },
   "dependencies": {
-    "@million/lint": "^1.0.0-rc.26",
     "@tailwindcss/typography": "^0.5.13",
     "@vercel/analytics": "^1.2.2",
     "@vercel/speed-insights": "^1.0.10",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://www.christinewessa.com/contact-christine</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://www.christinewessa.com</loc><changefreq>daily</changefreq><priority>0.8</priority></url>
+<url><loc>https://www.christinewessa.com/contact-christine</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://www.christinewessa.com/blog</loc><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
### TL;DR

This PR removes `@million/lint` from `next.config.mjs` and `package.json` and reorders the `<url>` tags in the `sitemap.xml` file.

### What changed?

- `@million/lint` has been removed from the `next.config.mjs` file.
- The dependency `@million/lint` has been removed from the `package.json` file.
- Reordered the `<url>` tags in the `sitemap.xml` file to ensure the correct order.

### How to test?

1. Verify that `@million/lint` is no longer present in `next.config.mjs`.
2. Verify that `@million/lint` is no longer a dependency in `package.json`.
3. Check that the `<url>` tags in `sitemap.xml` are in the correct order.

### Why make this change?

The `@million/lint` package is no longer needed, and cleanup is required. The reordering in `sitemap.xml` ensures consistency and correctness.

---