### PR TITLE
feat(forms): hide success and error messages

### DIFF
--- a/src/app/components/ContactForm.tsx
+++ b/src/app/components/ContactForm.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 export function ContactForm() {
   const formActionUrl = process.env.NEXT_PUBLIC_FORM_ACTION_URL;
   const turnstileKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
@@ -7,11 +9,12 @@ export function ContactForm() {
       <form
         action={formActionUrl}
         method="POST"
-        // target="_blank"
         className="space-y-4"
         data-basin-form
         data-basin-success-action="render"
         data-basin-spam-protection="turnstile"
+        data-basin-success-id="form-success"
+        data-basin-error-id="form-error"
       >
         <div className="flex gap-4">
           <div className="flex-1">
@@ -108,10 +111,10 @@ export function ContactForm() {
           Send Message
         </button>
       </form>
-      <div data-basin-success-id="form-success">
+      <div id="form-success" className="hidden">
         <p>Success content here</p>
       </div>
-      <div data-basin-error-id="form-failure">
+      <div id="form-error" className="hidden">
         <p>Failure content here</p>
       </div>
     </div>


### PR DESCRIPTION
### TL;DR

Enhance the ContactForm component to use the 'use client' directive and improve form handling with Basin success and error IDs.

### What changed?

- Added 'use client' directive at the top of `ContactForm.tsx`.
- Updated the form to include `data-basin-success-id` and `data-basin-error-id` attributes.
- Modified the success and error message divs to use `id` instead of `data-basin-*` attributes and added the `hidden` class.

### How to test?

1. Ensure the environment variables `NEXT_PUBLIC_FORM_ACTION_URL` and `NEXT_PUBLIC_TURNSTILE_SITE_KEY` are set.
2. Submit the ContactForm with valid and invalid data.
3. Observe if success or error messages are displayed as expected based on the form submission outcome.

### Why make this change?

To improve the client-side rendering by making the component use the `use client` directive and enhancing form handling for better UX using Basin's success and error IDs.

---

