### PR TITLE
refactor(forms): update location of Turnstile scripts

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -1,6 +1,6 @@
 import { Analytics } from "@vercel/analytics/react";
 import Script from "next/script";
-import Head from "next/head";
+// import Head from "next/head";
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import { Navbar } from "@/components/Navbar";
@@ -41,13 +41,13 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${OverusedGrotesk.variable}`}>
-      <Head>
+      {/* <Head>
         <script
           src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onloadTurnstileCallback"
           async
           defer
         ></script>
-      </Head>
+      </Head> */}
       <body className="bg-gray-50 text-gray-800 antialiased">
         <main className="flex min-h-svh flex-col">
           <Navbar />

--- a/src/app/components/ContactForm.tsx
+++ b/src/app/components/ContactForm.tsx
@@ -15,6 +15,7 @@ export function ContactForm() {
         data-basin-spam-protection="turnstile"
         data-basin-success-id="form-success"
         data-basin-error-id="form-error"
+        data-basin-turnstile-sitekey={turnstileKey}
       >
         <div className="flex gap-4">
           <div className="flex-1">
@@ -102,7 +103,7 @@ export function ContactForm() {
             required
           />
         </div>
-        <div className="cf-turnstile" data-sitekey={turnstileKey}></div>
+        {/* <div className="cf-turnstile" data-sitekey={turnstileKey}></div> */}
         <button
           type="submit"
           value="Submit"


### PR DESCRIPTION
### TL;DR

Commented out the usage of the `<Head>` component in `layout.tsx` and adjusted the script to load within a commented block. Additionally, updated the `ContactForm` component to use `data-basin-turnstile-sitekey` and commented out a redundant block.

### What changed?
- Commented out the usage of the `<Head>` component and the script block inside `layout.tsx`.
- Updated `ContactForm` to use `data-basin-turnstile-sitekey` attribute.
- Commented out redundant `cf-turnstile` div in `ContactForm`.

### How to test?
- Verify that the application loads the necessary scripts without relying on the `<Head>` component.
- Ensure that the `data-basin-turnstile-sitekey` attribute is correctly used in the `ContactForm`.
- Check if there are any issues due to the commented out `cf-turnstile` div.

### Why make this change?
To streamline the script loading and enhance the maintainability of the form component by updating attributes and removing redundant elements.

---

