### PR TITLE
chore(code): remove unneeded code from ContactForm

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -1,6 +1,5 @@
 import { Analytics } from "@vercel/analytics/react";
 import Script from "next/script";
-// import Head from "next/head";
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import { Navbar } from "@/components/Navbar";
@@ -41,13 +40,6 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${OverusedGrotesk.variable}`}>
-      {/* <Head>
-        <script
-          src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onloadTurnstileCallback"
-          async
-          defer
-        ></script>
-      </Head> */}
       <body className="bg-gray-50 text-gray-800 antialiased">
         <main className="flex min-h-svh flex-col">
           <Navbar />

--- a/src/app/components/ContactForm.tsx
+++ b/src/app/components/ContactForm.tsx
@@ -103,7 +103,6 @@ export function ContactForm() {
             required
           />
         </div>
-        {/* <div className="cf-turnstile" data-sitekey={turnstileKey}></div> */}
         <button
           type="submit"
           value="Submit"


### PR DESCRIPTION
### TL;DR
This PR removes commented-out Cloudflare Turnstile scripts from the layout and ContactForm components.

### What changed?
- Removed commented-out Turnstile script tags from `layout.tsx`
- Cleaned up `ContactForm.tsx` by deleting the commented-out Turnstile element

### How to test?
1. Verify that the application builds and runs without issues
2. Check that the removed comments do not affect any functionality since they were inactive

### Why make this change?
This change improves the codebase by cleaning up unnecessary commented-out code, making it easier to maintain and read.

---

