### PR TITLE
feat(cms): add Testimonials Payload collection

### DIFF
--- a/src/collections/BlogPosts.ts
+++ b/src/collections/BlogPosts.ts
@@ -5,6 +5,9 @@ export const BlogPosts: CollectionConfig = {
   admin: {
     useAsTitle: "posts",
   },
+  versions: {
+    drafts: true,
+  },
   fields: [
     {
       name: "posts",

--- a/src/collections/Testimonials.ts
+++ b/src/collections/Testimonials.ts
@@ -22,9 +22,20 @@ export const Testimonials: CollectionConfig = {
       label: "Role",
       required: true,
       admin: {
-        placeholder: "Saint",
+        placeholder: "e.g. Saint",
         description:
           "The role of the individual such as Director of Marriage and Family Life or Pastor",
+      },
+    },
+    {
+      name: "diocese",
+      type: "text",
+      label: "Diocese/Provincial",
+      required: true,
+      admin: {
+        placeholder: "e.g., Diocese of Pensacola-Tallahassee",
+        description:
+          "Where is the testimonial author located? For diocesan priests it would be their Diocese and for religious it would be their Provincial.",
       },
     },
   ],

--- a/src/collections/Testimonials.ts
+++ b/src/collections/Testimonials.ts
@@ -5,5 +5,27 @@ export const Testimonials: CollectionConfig = {
   admin: {
     useAsTitle: "name",
   },
-  fields: [{ name: "name", type: "text", label: "Name" }],
+  fields: [
+    {
+      name: "name",
+      type: "text",
+      label: "Name",
+      required: true,
+      admin: {
+        placeholder: "e.g. St. Therese of Lisieux",
+        description: "Add the name of the person who gave you the testimonial.",
+      },
+    },
+    {
+      name: "role",
+      type: "text",
+      label: "Role",
+      required: true,
+      admin: {
+        placeholder: "Saint",
+        description:
+          "The role of the individual such as Director of Marriage and Family Life or Pastor",
+      },
+    },
+  ],
 };

--- a/src/collections/Testimonials.ts
+++ b/src/collections/Testimonials.ts
@@ -1,0 +1,9 @@
+import { CollectionConfig } from "payload";
+
+export const Testimonials: CollectionConfig = {
+  slug: "testimonials",
+  admin: {
+    useAsTitle: "name",
+  },
+  fields: [{ name: "name", type: "text", label: "Name" }],
+};

--- a/src/collections/Testimonials.ts
+++ b/src/collections/Testimonials.ts
@@ -38,5 +38,14 @@ export const Testimonials: CollectionConfig = {
           "Where is the testimonial author located? For diocesan priests it would be their Diocese and for religious it would be their Provincial.",
       },
     },
+    {
+      name: "testimonial",
+      type: "richText",
+      label: "Testimonial",
+      required: true,
+      admin: {
+        description: "Add the testimonial content here.",
+      },
+    },
   ],
 };

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -118,7 +118,8 @@ export interface Post {
  */
 export interface Testimonial {
   id: string;
-  name?: string | null;
+  name: string;
+  role: string;
   updatedAt: string;
   createdAt: string;
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -122,6 +122,21 @@ export interface Testimonial {
   name: string;
   role: string;
   diocese: string;
+  testimonial: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  };
   updatedAt: string;
   createdAt: string;
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -111,6 +111,7 @@ export interface Post {
   };
   updatedAt: string;
   createdAt: string;
+  _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -120,6 +120,7 @@ export interface Testimonial {
   id: string;
   name: string;
   role: string;
+  diocese: string;
   updatedAt: string;
   createdAt: string;
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -14,6 +14,7 @@ export interface Config {
     users: User;
     media: Media;
     posts: Post;
+    testimonials: Testimonial;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
@@ -108,6 +109,16 @@ export interface Post {
     };
     [k: string]: unknown;
   };
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "testimonials".
+ */
+export interface Testimonial {
+  id: string;
+  name?: string | null;
   updatedAt: string;
   createdAt: string;
 }

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -11,6 +11,7 @@ import seoPlugin from "@payloadcms/plugin-seo";
 
 import { Users } from "./collections/Users";
 import { Media } from "./collections/Media";
+import { Testimonials } from "./collections/Testimonials";
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -54,7 +55,7 @@ export default buildConfig({
   admin: {
     user: Users.slug,
   },
-  collections: [Users, Media, BlogPosts],
+  collections: [Users, Media, BlogPosts, Testimonials],
   editor: lexicalEditor(),
   secret: PAYLOAD_SECRET || "",
   typescript: {


### PR DESCRIPTION

### TL;DR

This pull request adds a new 'Testimonials' collection to the project and enables draft support for the existing 'BlogPosts' collection.

### What changed?

- Added a Testimonials collection with fields for name, role, diocese, and testimonial content.
- Enabled draft support in the BlogPosts collection.
- Updated payload-types.ts to include the Testimonial interface.
- Updated payload.config.ts to register the Testimonials collection.

### How to test?

1. Run the project locally.
2. Check the admin panel to ensure the Testimonials collection is available and functional.
3. Create a new blog post and verify that draft mode is operational.

### Why make this change?

The addition of the Testimonials collection allows the system to capture and display testimonials from users, providing social proof and enhancing the site's credibility. Enabling draft support in the BlogPosts collection improves content management flexibility.

---

