### PR TITLE
feat(cms): add version control to Testimonials collection

### DIFF
--- a/src/collections/Testimonials.ts
+++ b/src/collections/Testimonials.ts
@@ -2,6 +2,9 @@ import { CollectionConfig } from "payload";
 
 export const Testimonials: CollectionConfig = {
   slug: "testimonials",
+  versions: {
+    drafts: true,
+  },
   admin: {
     useAsTitle: "name",
   },

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -139,6 +139,7 @@ export interface Testimonial {
   };
   updatedAt: string;
   createdAt: string;
+  _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
### TL;DR

Added draft functionality to the Testimonials collection in Payload CMS.

### What changed?

- Modified `Testimonials` collection to include draft versions.
- Updated `Testimonial` interface to support a `_status` field with values 'draft' or 'published'.

### How to test?

1. Go to the admin panel.
2. Navigate to the Testimonials collection.
3. Create a new testimonial and save it as a draft.
4. Verify the draft status in the collection view.

### Why make this change?

This change is motivated by the need to allow users to save testimonials as drafts before publishing them. It provides greater flexibility in managing content and ensures that testimonials can be reviewed and edited before going live.

---

