### PR TITLE
feat(cms): improve collection versions and labels

### DIFF
--- a/src/collections/BlogPosts.ts
+++ b/src/collections/BlogPosts.ts
@@ -7,6 +7,11 @@ export const BlogPosts: CollectionConfig = {
   },
   versions: {
     drafts: true,
+    maxPerDoc: 25,
+  },
+  labels: {
+    singular: "Post",
+    plural: "Posts",
   },
   fields: [
     {

--- a/src/collections/Testimonials.ts
+++ b/src/collections/Testimonials.ts
@@ -4,9 +4,14 @@ export const Testimonials: CollectionConfig = {
   slug: "testimonials",
   versions: {
     drafts: true,
+    maxPerDoc: 25,
   },
   admin: {
     useAsTitle: "name",
+  },
+  labels: {
+    singular: "Testimonial",
+    plural: "Testimonials",
   },
   fields: [
     {


### PR DESCRIPTION
### TL;DR

Enhanced BlogPosts and Testimonials collections with version control limits and custom labels.

### What changed?

- Added `maxPerDoc: 25` to version control for both BlogPosts and Testimonials
- Implemented custom labels for BlogPosts:
  - Singular: "Post"
  - Plural: "Posts"
- Implemented custom labels for Testimonials:
  - Singular: "Testimonial"
  - Plural: "Testimonials"

### How to test?

1. Navigate to the admin panel
2. Check the BlogPosts and Testimonials collections
3. Verify that the custom labels are displayed correctly
4. Create multiple versions of a document in each collection
5. Ensure that the version limit is enforced at 25 versions per document

### Why make this change?

This change improves the user experience in the admin panel by providing more accurate and intuitive labels for content types. Additionally, limiting the number of versions per document helps manage storage and improves system performance by preventing excessive version creation.

---

