### PR TITLE
fix(cms): update nameAsTitle on BlogPost collection

### DIFF
--- a/src/collections/BlogPosts.ts
+++ b/src/collections/BlogPosts.ts
@@ -3,7 +3,7 @@ import type { CollectionConfig } from "payload";
 export const BlogPosts: CollectionConfig = {
   slug: "posts",
   admin: {
-    useAsTitle: "posts",
+    useAsTitle: "name",
   },
   versions: {
     drafts: true,
@@ -15,7 +15,7 @@ export const BlogPosts: CollectionConfig = {
   },
   fields: [
     {
-      name: "posts",
+      name: "name",
       type: "text",
       label: "Name",
       required: true,

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -89,7 +89,7 @@ export interface Media {
  */
 export interface Post {
   id: string;
-  posts: string;
+  name: string;
   slug: string;
   mainImage?: string | Media | null;
   postedOn: string;


### PR DESCRIPTION
### TL;DR

Updated the BlogPosts collection to use "name" instead of "posts" for the title field.

### What changed?

- Modified the `useAsTitle` property in the BlogPosts collection from "posts" to "name"
- Changed the field name from "posts" to "name" in the BlogPosts collection
- Updated the Post interface in payload-types.ts to reflect the field name change from "posts" to "name"

### How to test?

1. Open the admin panel and navigate to the BlogPosts collection
2. Create a new blog post and verify that the "Name" field is used as the title
3. Check that existing blog posts display correctly with the updated field name
4. Ensure that the API responses for blog posts now include a "name" field instead of "posts"

### Why make this change?

This change improves the clarity and consistency of the BlogPosts collection by using a more appropriate field name for the post title. Using "name" instead of "posts" better represents the purpose of the field and aligns with common naming conventions for content management systems.

---

