### PR TITLE
feat(cms): add tabs and SEO plugin to BlogPosts

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -21,6 +21,11 @@ import { StrikethroughFeatureClient as StrikethroughFeatureClient_19 } from '@pa
 import { UnderlineFeatureClient as UnderlineFeatureClient_20 } from '@payloadcms/richtext-lexical/client'
 import { BoldFeatureClient as BoldFeatureClient_21 } from '@payloadcms/richtext-lexical/client'
 import { ItalicFeatureClient as ItalicFeatureClient_22 } from '@payloadcms/richtext-lexical/client'
+import { OverviewComponent as OverviewComponent_23 } from '@payloadcms/plugin-seo/client'
+import { MetaImageComponent as MetaImageComponent_24 } from '@payloadcms/plugin-seo/client'
+import { MetaTitleComponent as MetaTitleComponent_25 } from '@payloadcms/plugin-seo/client'
+import { MetaDescriptionComponent as MetaDescriptionComponent_26 } from '@payloadcms/plugin-seo/client'
+import { PreviewComponent as PreviewComponent_27 } from '@payloadcms/plugin-seo/client'
 
 export const importMap = {
   "@payloadcms/richtext-lexical/client#RichTextCell": RichTextCell_0,
@@ -45,5 +50,10 @@ export const importMap = {
   "@payloadcms/richtext-lexical/client#StrikethroughFeatureClient": StrikethroughFeatureClient_19,
   "@payloadcms/richtext-lexical/client#UnderlineFeatureClient": UnderlineFeatureClient_20,
   "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_21,
-  "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_22
+  "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_22,
+  "@payloadcms/plugin-seo/client#OverviewComponent": OverviewComponent_23,
+  "@payloadcms/plugin-seo/client#MetaImageComponent": MetaImageComponent_24,
+  "@payloadcms/plugin-seo/client#MetaTitleComponent": MetaTitleComponent_25,
+  "@payloadcms/plugin-seo/client#MetaDescriptionComponent": MetaDescriptionComponent_26,
+  "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_27
 }

--- a/src/collections/BlogPosts.ts
+++ b/src/collections/BlogPosts.ts
@@ -1,49 +1,76 @@
 import type { CollectionConfig } from "payload";
+import {
+  MetaDescriptionField,
+  MetaImageField,
+  MetaTitleField,
+  OverviewField,
+  PreviewField,
+} from "@payloadcms/plugin-seo/fields";
 
 export const BlogPosts: CollectionConfig = {
   slug: "posts",
-  admin: {
-    useAsTitle: "name",
-  },
-  versions: {
-    drafts: true,
-    maxPerDoc: 25,
-  },
-  labels: {
-    singular: "Post",
-    plural: "Posts",
-  },
   fields: [
     {
-      name: "name",
-      type: "text",
-      label: "Name",
-      required: true,
-      admin: {
-        description:
-          "The name of the post used around the site and seen in search engines. ",
-      },
-    },
-    {
-      name: "slug",
-      type: "text",
-      label: "Slug",
-      required: true,
-      admin: {
-        position: "sidebar",
-        description:
-          "The url that appears in search engines. If you ever change this, contact Kevin first.",
-      },
-    },
-    {
-      name: "mainImage",
-      type: "upload",
-      label: "Main Image",
-      relationTo: "media",
-      admin: {
-        description:
-          "This is the image that appears on the individual post as well as the PostCard displayed around the website.",
-      },
+      type: "tabs",
+      tabs: [
+        {
+          fields: [
+            {
+              name: "name",
+              type: "text",
+              label: "Name",
+              required: true,
+              admin: {
+                description:
+                  "The name of the post used around the site and seen in search engines. ",
+              },
+            },
+
+            {
+              name: "mainImage",
+              type: "upload",
+              label: "Main Image",
+              relationTo: "media",
+              admin: {
+                description:
+                  "This is the image that appears on the individual post as well as the PostCard displayed around the website.",
+              },
+            },
+            {
+              name: "content",
+              type: "richText",
+              label: "Main Content",
+              required: true,
+            },
+          ],
+          label: "Content",
+        },
+        {
+          name: "meta",
+          label: "SEO",
+          fields: [
+            OverviewField({
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+              imagePath: "meta.image",
+            }),
+            MetaImageField({
+              relationTo: "media",
+            }),
+            MetaTitleField({
+              hasGenerateFn: true,
+            }),
+            MetaDescriptionField({}),
+            PreviewField({
+              // if the `generateUrl` function is configured
+              hasGenerateFn: true,
+              // field paths to match the target field for data
+              titlePath: "meta.title",
+              descriptionPath: "meta.description",
+            }),
+          ],
+        },
+      ],
     },
     {
       name: "postedOn",
@@ -60,16 +87,27 @@ export const BlogPosts: CollectionConfig = {
       },
     },
     {
-      name: "description",
-      type: "textarea",
-      label: "Meta Description",
+      name: "slug",
+      type: "text",
+      label: "Slug",
       required: true,
-    },
-    {
-      name: "content",
-      type: "richText",
-      label: "Main Content",
-      required: true,
+      admin: {
+        position: "sidebar",
+        description:
+          "The url that appears in search engines. If you ever change this, contact Kevin first.",
+      },
     },
   ],
+  admin: {
+    useAsTitle: "name",
+    defaultColumns: ["name", "postedOn", "updatedAt"],
+  },
+  versions: {
+    drafts: true,
+    maxPerDoc: 25,
+  },
+  labels: {
+    singular: "Post",
+    plural: "Posts",
+  },
 };

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -90,10 +90,7 @@ export interface Media {
 export interface Post {
   id: string;
   name: string;
-  slug: string;
   mainImage?: string | Media | null;
-  postedOn: string;
-  description: string;
   content: {
     root: {
       type: string;
@@ -109,6 +106,13 @@ export interface Post {
     };
     [k: string]: unknown;
   };
+  meta?: {
+    image?: string | Media | null;
+    title?: string | null;
+    description?: string | null;
+  };
+  postedOn: string;
+  slug: string;
   updatedAt: string;
   createdAt: string;
   _status?: ('draft' | 'published') | null;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -12,7 +12,6 @@ import { fileURLToPath } from "url";
 import sharp from "sharp";
 import { s3Storage } from "@payloadcms/storage-s3";
 import { BlogPosts } from "./collections/BlogPosts";
-
 import { Users } from "./collections/Users";
 import { Media } from "./collections/Media";
 import { Testimonials } from "./collections/Testimonials";
@@ -85,6 +84,14 @@ export default buildConfig({
         region: "auto",
         endpoint: CLOUDFLARE_ENDPOINT,
         forcePathStyle: true,
+      },
+    }),
+    seoPlugin({
+      uploadsCollection: "media",
+      fieldOverrides: {
+        title: { required: false },
+        description: { required: false },
+        image: { required: false },
       },
     }),
   ],


### PR DESCRIPTION
### TL;DR

Added SEO functionality to the blog posts collection using the @payloadcms/plugin-seo package.

### What changed?

- Updated the BlogPosts collection configuration to include SEO fields
- Added SEO-related imports to the admin importMap
- Modified the payload config to include the SEO plugin
- Updated the Post interface in payload-types.ts to reflect the new SEO fields

### How to test?

1. Navigate to the admin panel and create or edit a blog post
2. Verify that a new "SEO" tab is present in the blog post editor
3. Check that you can add SEO-related information such as meta title, description, and image
4. Ensure that the SEO preview functionality works correctly

### Why make this change?

This change enhances the SEO capabilities of the blog posts, allowing for better control over how posts appear in search engine results. It provides a user-friendly interface for content creators to optimize their posts for search engines, potentially improving visibility and traffic to the site.

---

