### PR TITLE
feat(cms): add access control to Payload cms

### DIFF
--- a/src/collections/Users.ts
+++ b/src/collections/Users.ts
@@ -1,13 +1,16 @@
-import type { CollectionConfig } from 'payload'
+import type { CollectionConfig } from "payload";
+
+import { authenticated } from "@/payload/access/authenticated";
 
 export const Users: CollectionConfig = {
-  slug: 'users',
+  slug: "users",
+
+  //* Collection Fields
+  fields: [{ name: "name", type: "text", label: "Full Name" }],
+
+  //* Admin Settings
   admin: {
-    useAsTitle: 'email',
+    useAsTitle: "name",
   },
   auth: true,
-  fields: [
-    // Email added by default
-    // Add more fields as needed
-  ],
-}
+};

--- a/src/collections/Users.ts
+++ b/src/collections/Users.ts
@@ -1,5 +1,4 @@
 import type { CollectionConfig } from "payload";
-
 import { authenticated } from "@/payload/access/authenticated";
 
 export const Users: CollectionConfig = {
@@ -9,6 +8,13 @@ export const Users: CollectionConfig = {
   fields: [{ name: "name", type: "text", label: "Full Name" }],
 
   //* Admin Settings
+  access: {
+    admin: authenticated,
+    create: authenticated,
+    delete: authenticated,
+    read: authenticated,
+    update: authenticated,
+  },
   admin: {
     useAsTitle: "name",
   },

--- a/src/payload/access/anyone.ts
+++ b/src/payload/access/anyone.ts
@@ -1,0 +1,3 @@
+import type { Access } from "payload";
+
+export const anyone: Access = () => true;

--- a/src/payload/access/authenticated.ts
+++ b/src/payload/access/authenticated.ts
@@ -1,0 +1,12 @@
+import type { AccessArgs } from "payload";
+
+import type { User } from "../../payload-types";
+
+type isAuthenticated = (args: AccessArgs<User>) => boolean;
+
+export const authenticated: isAuthenticated = ({ req: { user } }) => {
+  if (user) {
+    return true;
+  }
+  return false;
+};

--- a/src/payload/access/authenticatedOrPublished.ts
+++ b/src/payload/access/authenticatedOrPublished.ts
@@ -1,0 +1,13 @@
+import type { Access } from "payload";
+
+export const authenticatedOrPublished: Access = ({ req: { user } }) => {
+  if (user) {
+    return true;
+  }
+
+  return {
+    _status: {
+      equals: "published",
+    },
+  };
+};


### PR DESCRIPTION
### TL;DR

Enhanced user management and access control in the application.

### What changed?

- Updated the Users collection configuration:
  - Added a "name" field for full name
  - Implemented authenticated access controls for admin, create, delete, read, and update operations
  - Changed the admin title field from "email" to "name"
- Created new access control functions:
  - `anyone`: Allows unrestricted access
  - `authenticated`: Checks if a user is logged in
  - `authenticatedOrPublished`: Allows access for authenticated users or to published content

### How to test?

1. Create a new user account
2. Attempt to access user management features while logged in and logged out
3. Verify that only authenticated users can perform CRUD operations on user data
4. Check if the admin panel displays the user's name as the title

### Why make this change?

This change improves the security and functionality of the user management system. By implementing proper access controls, we ensure that only authenticated users can perform sensitive operations. Additionally, the new "name" field provides a more user-friendly way to identify users in the admin panel.

---

