### PR TITLE
feat(cms): connect BlogPosts to frontend journal page

### DIFF
--- a/src/app/(frontend)/journal/page.tsx
+++ b/src/app/(frontend)/journal/page.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { getPayloadHMR } from "@payloadcms/next/utilities";
+import configPromise from "@payload-config";
+
+export default async function Page() {
+  const payload = await getPayloadHMR({ config: configPromise });
+  const posts = await payload.find({
+    collection: "posts",
+    limit: 1000,
+    sort: "-publishedDate",
+    where: {
+      slug: {
+        exists: true,
+      },
+    },
+  });
+  return (
+    <div className="pb-24 pt-24">
+      <div className="container mx-auto mb-16">
+        <h1 className="text-3xl">Posts</h1>
+        <div>
+          {posts.docs.map((post: any) => {
+            return (
+              <div key={post.id} className="mb-2">
+                <h2 className="text-3xl">{post.name}</h2>
+                <p>{post.slug}</p>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### TL;DR

Added a new journal page to display posts.

### What changed?

Created a new file `src/app/(frontend)/journal/page.tsx` that implements a React component to fetch and display posts. The component uses Payload CMS to retrieve posts, sorting them by publish date and ensuring they have a slug.

### How to test?

1. Navigate to the journal page in the application.
2. Verify that posts are displayed with their names and slugs.
3. Ensure the posts are sorted in descending order by publish date.
4. Check that only posts with existing slugs are shown.

### Why make this change?

This change introduces a dedicated journal page to showcase posts, improving content discoverability and user experience. It provides a centralized location for users to browse through available posts, making it easier to find and access content.

---

