### PR TITLE
feat(cms): convert Footer to Payload component

### DIFF
--- a/src/app/(frontend)/journal/page.tsx
+++ b/src/app/(frontend)/journal/page.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import { getPayloadHMR } from "@payloadcms/next/utilities";
 import configPromise from "@payload-config";
 
+export const dynamic = "force-static";
+export const revalidate = 600;
+
 export default async function Page() {
   const payload = await getPayloadHMR({ config: configPromise });
   const posts = await payload.find({

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -3,7 +3,7 @@ import Script from "next/script";
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import { Navbar } from "@/components/Navbar";
-import { Footer } from "@/components/Footer";
+import { Footer } from "@/components/Footer/index";
 import "./globals.css";
 
 const OverusedGrotesk = localFont({

--- a/src/app/components/Footer/index.tsx
+++ b/src/app/components/Footer/index.tsx
@@ -1,5 +1,8 @@
+import React from "react";
+import { getPayloadHMR } from "@payloadcms/next/utilities";
+import config from "@payload-config";
 import Link from "next/link";
-import socialIconsData from "../data/socialIconsData";
+import socialIconsData from "@/data/socialIconsData";
 
 export function Footer() {
   const getCurrentYear = (): number => {

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -21,7 +21,10 @@ export interface Config {
   db: {
     defaultIDType: string;
   };
-  globals: {};
+  globals: {
+    header: Header;
+    footer: Footer;
+  };
   locale: null;
   user: User & {
     collection: 'users';
@@ -179,6 +182,26 @@ export interface PayloadMigration {
   batch?: number | null;
   updatedAt: string;
   createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "header".
+ */
+export interface Header {
+  id: string;
+  logo: string | Media;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "footer".
+ */
+export interface Footer {
+  id: string;
+  logo?: string | Media | null;
+  updatedAt?: string | null;
+  createdAt?: string | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -15,6 +15,8 @@ import { BlogPosts } from "./payload/collections/BlogPosts";
 import { Users } from "./payload/collections/Users";
 import { Media } from "./payload/collections/Media";
 import { Testimonials } from "./payload/collections/Testimonials";
+import { Header } from "./payload/globals/Header";
+import { Footer } from "./payload/globals/Footer";
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -59,6 +61,7 @@ export default buildConfig({
     user: Users.slug,
   },
   collections: [Users, Media, BlogPosts, Testimonials],
+  globals: [Header, Footer],
   editor: lexicalEditor(),
   secret: PAYLOAD_SECRET || "",
   typescript: {

--- a/src/payload/globals/Footer.tsx
+++ b/src/payload/globals/Footer.tsx
@@ -1,0 +1,21 @@
+import type { GlobalConfig } from "payload";
+
+export const Footer: GlobalConfig = {
+  slug: "footer",
+
+  //* Global Fields
+  fields: [
+    {
+      name: "logo",
+      type: "upload",
+      relationTo: "media",
+      label: "logo",
+      required: false,
+    },
+  ],
+
+  //* Admin Settings
+  access: {
+    read: () => true,
+  },
+};

--- a/src/payload/globals/Header.tsx
+++ b/src/payload/globals/Header.tsx
@@ -1,0 +1,21 @@
+import type { GlobalConfig } from "payload";
+
+export const Header: GlobalConfig = {
+  slug: "header",
+
+  //* Global Fields
+  fields: [
+    {
+      name: "logo",
+      type: "upload",
+      relationTo: "media",
+      label: "logo",
+      required: true,
+    },
+  ],
+
+  //* Admin Settings
+  access: {
+    read: () => true,
+  },
+};


### PR DESCRIPTION
### TL;DR

Added Header and Footer globals, updated Footer component, and implemented static generation for the journal page.

### What changed?

- Created new Header and Footer global configurations in Payload CMS
- Moved Footer component to its own directory and updated imports
- Added static generation settings to the journal page
- Updated payload config to include new globals
- Modified payload types to reflect new global structures

### How to test?

1. Check the Payload CMS admin panel for new Header and Footer globals
2. Verify that the Footer component still renders correctly on the frontend
3. Test the journal page to ensure it's statically generated and revalidates every 10 minutes
4. Confirm that the logo upload functionality works in both Header and Footer globals

### Why make this change?

This change improves the site's structure and performance by:

1. Allowing easier management of header and footer content through Payload CMS
2. Optimizing the journal page for static generation, reducing server load and improving load times
3. Enhancing the modularity of the Footer component for better maintainability
4. Providing a consistent way to manage logos across the site

---

