### PR TITLE
feat(cms): add RichText component and helper functions to serialize lexical rich text

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@tailwindcss/typography": "^0.5.15",
     "@vercel/analytics": "^1.3.1",
     "@vercel/speed-insights": "^1.0.12",
+    "escape-html": "^1.0.3",
     "graphql": "^16.9.0",
     "next": "15.0.0-canary.104",
     "next-sitemap": "^4.2.3",
@@ -41,6 +42,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
+    "@types/escape-html": "^1.0.4",
     "@types/node": "^20.16.2",
     "@types/react": "npm:types-react@19.0.0-rc.0",
     "@types/react-dom": "npm:types-react-dom@19.0.0-rc.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@vercel/speed-insights':
         specifier: ^1.0.12
         version: 1.0.12(next@15.0.0-canary.104(react-dom@19.0.0-rc-06d0b89e-20240801(react@19.0.0-rc-06d0b89e-20240801))(react@19.0.0-rc-06d0b89e-20240801)(sass@1.77.4))(react@19.0.0-rc-06d0b89e-20240801)
+      escape-html:
+        specifier: ^1.0.3
+        version: 1.0.3
       graphql:
         specifier: ^16.9.0
         version: 16.9.0
@@ -90,6 +93,9 @@ importers:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.10)
     devDependencies:
+      '@types/escape-html':
+        specifier: ^1.0.4
+        version: 1.0.4
       '@types/node':
         specifier: ^20.16.2
         version: 20.16.2
@@ -1262,8 +1268,8 @@ packages:
   '@radix-ui/react-primitive@2.0.0':
     resolution: {integrity: sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==}
     peerDependencies:
-      '@types/react': npm:types-react@19.0.0-rc.0
-      '@types/react-dom': npm:types-react-dom@19.0.0-rc.0
+      '@types/react': '*'
+      '@types/react-dom': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -1333,7 +1339,7 @@ packages:
   '@radix-ui/react-use-previous@1.1.0':
     resolution: {integrity: sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==}
     peerDependencies:
-      '@types/react': npm:types-react@19.0.0-rc.0
+      '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
@@ -1599,6 +1605,9 @@ packages:
 
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@types/escape-html@1.0.4':
+    resolution: {integrity: sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==}
 
   '@types/glob@7.2.0':
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
@@ -6237,6 +6246,8 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@types/escape-html@1.0.4': {}
+
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
@@ -7015,7 +7026,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
       eslint-plugin-react: 7.35.0(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -7046,7 +7057,7 @@ snapshots:
       is-bun-module: 1.1.0
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -7064,7 +7075,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5

--- a/src/app/(frontend)/journal/[...slug.tsx]/page.tsx
+++ b/src/app/(frontend)/journal/[...slug.tsx]/page.tsx
@@ -1,0 +1,3 @@
+export default function blogPost() {
+  return <div>Hello</div>;
+}

--- a/src/app/components/RichText/RichText.tsx
+++ b/src/app/components/RichText/RichText.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { serializeLexical } from "./serializeLexical";
+import { LexicalNode } from "./lexicalNodeFormat";
+
+// If you have a utility for class names, import it here
+// import { cn } from '@/utilities/cn';
+
+// If you don't have the cn utility, you can use this simple function:
+const cn = (...classes: (string | boolean | undefined | null)[]): string => {
+  return classes.filter(Boolean).join(" ");
+};
+
+type Props = {
+  className?: string;
+  content: Record<string, any>;
+  enableGutter?: boolean;
+  enableProse?: boolean;
+};
+
+const RichText: React.FC<Props> = ({
+  className,
+  content,
+  enableGutter = true,
+  enableProse = true,
+}) => {
+  if (!content) {
+    return null;
+  }
+  return (
+    <div
+      className={cn(
+        enableGutter ? "container" : "max-w-none",
+        enableProse ? "prose mx-auto dark:prose-invert" : "",
+        className,
+      )}
+    >
+      {content &&
+        !Array.isArray(content) &&
+        typeof content === "object" &&
+        "root" in content &&
+        serializeLexical({ nodes: content?.root?.children as LexicalNode[] })}
+    </div>
+  );
+};
+
+export default RichText;

--- a/src/app/components/RichText/RichText.tsx
+++ b/src/app/components/RichText/RichText.tsx
@@ -2,14 +2,13 @@ import React from "react";
 import { serializeLexical } from "./serializeLexical";
 import { LexicalNode } from "./lexicalNodeFormat";
 
-// If you have a utility for class names, import it here
-// import { cn } from '@/utilities/cn';
-
-// If you don't have the cn utility, you can use this simple function:
+// Simple utility function to concatenate class names
+// This can be replaced with a more robust solution if needed
 const cn = (...classes: (string | boolean | undefined | null)[]): string => {
   return classes.filter(Boolean).join(" ");
 };
 
+// Props interface for the RichText component
 type Props = {
   className?: string;
   content: Record<string, any>;
@@ -17,15 +16,18 @@ type Props = {
   enableProse?: boolean;
 };
 
+// RichText component for rendering Lexical content
 const RichText: React.FC<Props> = ({
   className,
   content,
   enableGutter = true,
   enableProse = true,
 }) => {
+  // Return null if no content is provided
   if (!content) {
     return null;
   }
+
   return (
     <div
       className={cn(
@@ -34,6 +36,7 @@ const RichText: React.FC<Props> = ({
         className,
       )}
     >
+      {/* Render the content if it's a valid Lexical structure */}
       {content &&
         !Array.isArray(content) &&
         typeof content === "object" &&

--- a/src/app/components/RichText/lexicalNodeFormat.tsx
+++ b/src/app/components/RichText/lexicalNodeFormat.tsx
@@ -1,0 +1,35 @@
+export const IS_BOLD = 1;
+export const IS_ITALIC = 1 << 1;
+export const IS_STRIKETHROUGH = 1 << 2;
+export const IS_UNDERLINE = 1 << 3;
+export const IS_CODE = 1 << 4;
+export const IS_SUBSCRIPT = 1 << 5;
+export const IS_SUPERSCRIPT = 1 << 6;
+
+export type TextNode = {
+  type: "text";
+  text: string;
+  format: number;
+  version: number;
+};
+
+export type ElementNode = {
+  type:
+    | "root"
+    | "paragraph"
+    | "heading"
+    | "quote"
+    | "list"
+    | "listitem"
+    | "link";
+  children: LexicalNode[];
+  direction?: "ltr" | "rtl";
+  format?: number;
+  indent?: number;
+  version: number;
+  tag?: string;
+  listType?: "bullet" | "number";
+  url?: string;
+};
+
+export type LexicalNode = TextNode | ElementNode;

--- a/src/app/components/RichText/lexicalNodeFormat.tsx
+++ b/src/app/components/RichText/lexicalNodeFormat.tsx
@@ -1,3 +1,5 @@
+// Constants for text formatting
+// These use bitwise flags for efficient storage and checking of multiple formats
 export const IS_BOLD = 1;
 export const IS_ITALIC = 1 << 1;
 export const IS_STRIKETHROUGH = 1 << 2;
@@ -6,13 +8,15 @@ export const IS_CODE = 1 << 4;
 export const IS_SUBSCRIPT = 1 << 5;
 export const IS_SUPERSCRIPT = 1 << 6;
 
+// Type definition for a text node in the Lexical structure
 export type TextNode = {
   type: "text";
   text: string;
-  format: number;
+  format: number; // Bitwise combination of formatting constants
   version: number;
 };
 
+// Type definition for an element node in the Lexical structure
 export type ElementNode = {
   type:
     | "root"
@@ -27,9 +31,10 @@ export type ElementNode = {
   format?: number;
   indent?: number;
   version: number;
-  tag?: string;
+  tag?: string; // Used for heading levels (h1, h2, etc.)
   listType?: "bullet" | "number";
-  url?: string;
+  url?: string; // Used for links
 };
 
+// Union type for all possible Lexical nodes
 export type LexicalNode = TextNode | ElementNode;

--- a/src/app/components/RichText/serializeLexical.tsx
+++ b/src/app/components/RichText/serializeLexical.tsx
@@ -1,0 +1,102 @@
+import React, { Fragment } from "react";
+import escapeHTML from "escape-html";
+import {
+  LexicalNode,
+  TextNode,
+  ElementNode,
+  IS_BOLD,
+  IS_ITALIC,
+  IS_STRIKETHROUGH,
+  IS_UNDERLINE,
+  IS_CODE,
+  IS_SUBSCRIPT,
+  IS_SUPERSCRIPT,
+} from "./lexicalNodeFormat";
+
+export const serializeLexical = ({
+  nodes,
+}: {
+  nodes: LexicalNode[];
+}): React.ReactNode => {
+  return nodes.map((node, i) => {
+    if (node.type === "text") {
+      const textNode = node as TextNode;
+      let text = <Fragment key={i}>{escapeHTML(textNode.text)}</Fragment>;
+
+      if (textNode.format & IS_BOLD) {
+        text = <strong key={i}>{text}</strong>;
+      }
+      if (textNode.format & IS_ITALIC) {
+        text = <em key={i}>{text}</em>;
+      }
+      if (textNode.format & IS_STRIKETHROUGH) {
+        text = <s key={i}>{text}</s>;
+      }
+      if (textNode.format & IS_UNDERLINE) {
+        text = <u key={i}>{text}</u>;
+      }
+      if (textNode.format & IS_CODE) {
+        text = <code key={i}>{text}</code>;
+      }
+      if (textNode.format & IS_SUBSCRIPT) {
+        text = <sub key={i}>{text}</sub>;
+      }
+      if (textNode.format & IS_SUPERSCRIPT) {
+        text = <sup key={i}>{text}</sup>;
+      }
+
+      return text;
+    }
+
+    if (!node) {
+      return null;
+    }
+
+    const elementNode = node as ElementNode;
+
+    switch (elementNode.type) {
+      case "root":
+        return (
+          <Fragment key={i}>
+            {serializeLexical({ nodes: elementNode.children })}
+          </Fragment>
+        );
+      case "paragraph":
+        return (
+          <p key={i}>{serializeLexical({ nodes: elementNode.children })}</p>
+        );
+      case "heading":
+        const Tag = `h${elementNode.tag}` as keyof JSX.IntrinsicElements;
+        return (
+          <Tag key={i}>{serializeLexical({ nodes: elementNode.children })}</Tag>
+        );
+      case "quote":
+        return (
+          <blockquote key={i}>
+            {serializeLexical({ nodes: elementNode.children })}
+          </blockquote>
+        );
+      case "list":
+        const ListTag = elementNode.listType === "number" ? "ol" : "ul";
+        return (
+          <ListTag key={i}>
+            {serializeLexical({ nodes: elementNode.children })}
+          </ListTag>
+        );
+      case "listitem":
+        return (
+          <li key={i}>{serializeLexical({ nodes: elementNode.children })}</li>
+        );
+      case "link":
+        return (
+          <a href={escapeHTML(elementNode.url || "")} key={i}>
+            {serializeLexical({ nodes: elementNode.children })}
+          </a>
+        );
+      default:
+        return (
+          <p key={i}>{serializeLexical({ nodes: elementNode.children })}</p>
+        );
+    }
+  });
+};

--- a/src/app/components/RichText/serializeLexical.tsx
+++ b/src/app/components/RichText/serializeLexical.tsx
@@ -13,16 +13,19 @@ import {
   IS_SUPERSCRIPT,
 } from "./lexicalNodeFormat";
 
+// Main function to serialize Lexical nodes into React elements
 export const serializeLexical = ({
   nodes,
 }: {
   nodes: LexicalNode[];
 }): React.ReactNode => {
   return nodes.map((node, i) => {
+    // Handle text nodes
     if (node.type === "text") {
       const textNode = node as TextNode;
       let text = <Fragment key={i}>{escapeHTML(textNode.text)}</Fragment>;
 
+      // Apply text formatting based on the format bitfield
       if (textNode.format & IS_BOLD) {
         text = <strong key={i}>{text}</strong>;
       }
@@ -48,12 +51,14 @@ export const serializeLexical = ({
       return text;
     }
 
+    // Return null for undefined nodes
     if (!node) {
       return null;
     }
 
     const elementNode = node as ElementNode;
 
+    // Handle different types of element nodes
     switch (elementNode.type) {
       case "root":
         return (
@@ -94,6 +99,7 @@ export const serializeLexical = ({
           </a>
         );
       default:
+        // Default to a paragraph if the element type is not recognized
         return (
           <p key={i}>{serializeLexical({ nodes: elementNode.children })}</p>
         );


### PR DESCRIPTION
### TL;DR

Added a RichText component for rendering Lexical content with support for various text formatting and element types.

### What changed?

- Created a new `RichText` component in `src/app/components/RichText/RichText.tsx`
- Implemented `serializeLexical` function to convert Lexical nodes into React elements
- Defined types and constants for Lexical node formats in `lexicalNodeFormat.tsx`
- Added `escape-html` dependency for safe HTML rendering
- Created a placeholder for a blog post page

### How to test?

1. Import the `RichText` component in a page or component file
2. Pass Lexical content to the `RichText` component:
   ```jsx
   <RichText content={lexicalContent} />
   ```
3. Verify that the content renders correctly with proper formatting and structure
4. Test different content types: paragraphs, headings, lists, links, and text formatting

### Why make this change?

This change introduces a flexible and reusable component for rendering rich text content stored in Lexical format. It enables the application to display formatted content from a CMS or editor that uses Lexical, improving the overall content presentation capabilities of the project.

---

